### PR TITLE
enable testspace to capture tests only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
   include:
     - node_js: "4"
       env: TEST_SUITE=lint
-  fast_finish: true
+  fast_finish: false
 
 branches:
   except:
@@ -37,10 +37,18 @@ branches:
 
 before_install:
   - if [ $DB == "mysql" ]; then mysql -e 'create database ghost_testing'; fi
+  - mkdir -p $HOME/bin
+  - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url open.testspace.com
 
 install:
   - yarn
   - if [ "$DB" == "sqlite3" ]; then yarn add --force sqlite3; fi # fix sqlite caching issues
+
+after_script:
+   - if [ "${TEST_SUITE}" != "lint" ]; then
+       testspace [Node-$TRAVIS_NODE_VERSION-$DB/]*-xunit.xml{core};
+     fi 
 
 after_success:
   - |

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,7 +140,7 @@ var overrides      = require('./core/server/overrides'),
             mochacli: {
                 options: {
                     ui: 'bdd',
-                    reporter: grunt.option('reporter') || 'spec',
+                    reporter: grunt.option('reporter') || 'spec-xunit-file',
                     timeout: '30000',
                     save: grunt.option('reporter-output'),
                     require: ['core/server/overrides']
@@ -151,7 +151,10 @@ var overrides      = require('./core/server/overrides'),
                     src: [
                         'core/test/unit/**/*_spec.js',
                         'core/server/apps/**/tests/*_spec.js'
-                    ]
+                    ],
+                    options: {
+                        env: {XUNIT_FILE: 'unit-xunit.xml'}
+                    }
                 },
 
                 // #### All Integration tests
@@ -159,21 +162,30 @@ var overrides      = require('./core/server/overrides'),
                     src: [
                         'core/test/integration/**/*_spec.js',
                         'core/test/integration/*_spec.js'
-                    ]
+                    ],
+                    options: {
+                        env: {XUNIT_FILE: 'integration-xunit.xml'}
+                    }
                 },
 
                 // #### All Route tests
                 routes: {
                     src: [
                         'core/test/functional/routes/**/*_spec.js'
-                    ]
+                    ],
+                    options: {
+                        env: {XUNIT_FILE: 'route-xunit.xml'}
+                    }
                 },
 
                 // #### All Module tests
                 module: {
                     src: [
                         'core/test/functional/module/**/*_spec.js'
-                    ]
+                    ],
+                    options: {
+                        env: {XUNIT_FILE: 'module-xunit.xml'}
+                    }
                 },
 
                 // #### Run single test (src is set dynamically, see grunt task 'test')

--- a/core/test/unit/utils/make-absolute-urls_spec.js
+++ b/core/test/unit/utils/make-absolute-urls_spec.js
@@ -2,7 +2,7 @@ var should = require('should'), // jshint ignore:line
     makeAbsoluteUrls = require('../../../server/utils/make-absolute-urls'),
     configUtils = require('../../utils/configUtils');
 
-describe('Make absolute URLs ', function () {
+describe('Make absolute URLs', function () {
     var siteUrl = 'http://my-ghost-blog.com',
         itemUrl = 'my-awesome-post';
 

--- a/core/test/unit/utils/mobiledoc-converter_spec.js
+++ b/core/test/unit/utils/mobiledoc-converter_spec.js
@@ -1,7 +1,7 @@
 var should = require('should'), // jshint ignore:line
     converter = require('../../../server/utils/mobiledoc-converter');
 
-describe('Convert mobiledoc to HTML ', function () {
+describe('Convert mobiledoc to HTML', function () {
     var mobiledoc = {
         version: '0.3.1',
         atoms: [],

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "semver": "5.3.0",
     "simple-dom": "0.3.2",
     "simple-html-tokenizer": "0.4.1",
+    "spec-xunit-file": "0.0.1-3",
     "superagent": "3.5.2",
     "unidecode": "0.1.8",
     "uuid": "3.0.1",


### PR DESCRIPTION
Providing the required `set of changes` required and example test content reporting.  

- added Testspace client installation to travis
- updates to support junit output
- fixed 2 tests using white space (prevents reporting based on src dir)

---
Note, the actual URL used in the .travis.yml should be changed to ghost (assuming an organization is created). 

`testspace config url ghost.testspace.com`  (line 42, replace `open` with `ghost`)

